### PR TITLE
Fix test hungup, exited and blocking not allow preempt

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -79,7 +79,10 @@ pub fn on_timer_tick() {
 /// disable_preempt ctx
 pub fn current_check_preempt_pending() {
     let curr = crate::current();
-    if curr.get_preempt_pending() && curr.can_preempt() {
+    // if task is already exited or blocking,
+    // no need preempt, they are rescheduling
+    if curr.get_preempt_pending() && curr.can_preempt() &&
+        !curr.is_exited() && !curr.is_blocking(){
         debug!(
             "current {} is to be preempted , allow {}",
             curr.id_name(),

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -62,7 +62,6 @@ pub fn schedule_timeout(deadline: axhal::time::TimeValue) -> bool {
     debug!("task sleep: {}, deadline={:?}", curr.id_name(), deadline);
     assert!(!curr.is_idle());
     crate::timers::set_alarm_wakeup(deadline, curr.clone());
-    curr.set_state(TaskState::Blocking);
     schedule();
     let timeout = axhal::time::current_time() >= deadline;
     // may wake up by others

--- a/src/task.rs
+++ b/src/task.rs
@@ -74,10 +74,22 @@ impl ScheduleTask {
         *self.state.lock() = state
     }
 
-    /// Whether the task is ready to be scheduled
+    /// Whether the task is Exited
+    #[inline]
+    pub fn is_exited(&self) -> bool {
+        matches!(*self.state.lock(), TaskState::Exited)
+    }
+
+    /// Whether the task is runnalbe
     #[inline]
     pub fn is_runable(&self) -> bool {
         matches!(*self.state.lock(), TaskState::Runable)
+    }
+
+    /// Whether the task is blocking
+    #[inline]
+    pub fn is_blocking(&self) -> bool {
+        matches!(*self.state.lock(), TaskState::Blocking)
     }
 
     /// Whether the task is blocked


### PR DESCRIPTION
--------
Sleep:
 // before no timer.lock()
 task.state = Blocking
                        ----> timer irq: preempt happend
                              reschedule: task.state = Blocked
 			      switch_to(next)
Here would never excute
timer_list.add(task)

Wait is similar
---------------
Wait Timeout is more complicated
 wait.lock()
 task.state = Blocking
 wait_list.add(task)
 wait.unlock()
		        ------> timer irq happend
                                reschedule: task.state = blocked
                                switch_to(next)

If no one notify,here would never excute
timer_list.add(task)

---------
TaskA:
 wait.lock()
 task.state = Blocking
 wait_list.add(task)
 wait.unlock()			TaskB
		      ------> timer irq happend
                              reschedule: taskA.state = blocked
                              switch_to(TaskB)
			      Here: TaskA CTX is empty
 			      wakeup(TaskA)